### PR TITLE
Check assert statements with nonsense expressions

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -631,7 +631,7 @@ class Checker(object):
 
     # "stmt" type nodes
     DELETE = PRINT = FOR = WHILE = IF = WITH = WITHITEM = RAISE = \
-        TRYFINALLY = ASSERT = EXEC = EXPR = ASSIGN = handleChildren
+        TRYFINALLY = EXEC = EXPR = ASSIGN = handleChildren
 
     CONTINUE = BREAK = PASS = ignore
 
@@ -705,6 +705,18 @@ class Checker(object):
         self.scope.isGenerator = True
         self.handleNode(node.value, node)
 
+    def ASSERT(self, node):
+        test = node.test
+
+        if ((isinstance(test, (ast.Tuple, ast.List, ast.Set)) and 
+             test.elts) or
+            (isinstance(test, (ast.Dict)) and test.keys) or
+            (isinstance(test, ast.Str) and test.s) or 
+            (isinstance(test, ast.Num) and test.n)):
+            self.report(messages.AssertTrivallyTrue, node.test)
+
+        self.handleChildren(node)
+            
     YIELDFROM = YIELD
 
     def FUNCTIONDEF(self, node):

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -708,15 +708,19 @@ class Checker(object):
     def ASSERT(self, node):
         test = node.test
 
-        if ((isinstance(test, (ast.Tuple, ast.List, ast.Set)) and 
-             test.elts) or
-            (isinstance(test, (ast.Dict)) and test.keys) or
-            (isinstance(test, ast.Str) and test.s) or 
-            (isinstance(test, ast.Num) and test.n)):
+        if (
+            (
+                isinstance(test, (ast.Tuple, ast.List, ast.Set))
+                and test.elts
+            )
+            or (isinstance(test, (ast.Dict)) and test.keys)
+            or (isinstance(test, ast.Str) and test.s)
+            or (isinstance(test, ast.Num) and test.n)
+        ):
             self.report(messages.AssertTrivallyTrue, node.test)
 
         self.handleChildren(node)
-            
+
     YIELDFROM = YIELD
 
     def FUNCTIONDEF(self, node):

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -133,3 +133,7 @@ class ReturnWithArgsInsideGenerator(Message):
     Indicates a return statement with arguments inside a generator.
     """
     message = '\'return\' with argument inside generator'
+
+
+class AssertTrivallyTrue(Message):
+    message = '\'assert\' with trivally True expression.'

--- a/pyflakes/test/test_asserts.py
+++ b/pyflakes/test/test_asserts.py
@@ -1,0 +1,39 @@
+from pyflakes import messages as m
+from pyflakes.test.harness import TestCase
+
+class Test(TestCase):
+    def test_Asserts_intentionally_simple_pass(self):
+        self.flakes("""
+        assert True
+        assert False
+        """)
+
+    def test_Asserts_nontrivial_pass(self):
+        self.flakes("""
+        d = {'a': 1, 'b': 2}
+        l = [1, 2]
+        n = 10
+        s = {1, 2}
+        t = (1, 2)
+        needle = 'needle'
+        assert d == {'a': 3}
+        assert n == 10
+        assert l == [1, 2]        
+        assert s == {1, 2}
+        assert t == (1, 2)
+        assert needle in "haystack"
+        """)
+
+    def test_Asserts_triviallyTrue_fail(self):
+        self.flakes("""
+        assert ("Any", "Tuple", "Really")
+        assert "Non empty string"
+        assert b"Non empty binary"
+        assert ["Non", "empty", "list"]
+        assert {1, 2, 3}
+        assert {'a': 2, 'b': 3}
+        assert 1
+        assert 1.0
+        """,
+                    *[m.AssertTrivallyTrue]*8)
+

--- a/pyflakes/test/test_asserts.py
+++ b/pyflakes/test/test_asserts.py
@@ -1,6 +1,7 @@
 from pyflakes import messages as m
 from pyflakes.test.harness import TestCase
 
+
 class Test(TestCase):
     def test_Asserts_intentionally_simple_pass(self):
         self.flakes("""
@@ -18,7 +19,7 @@ class Test(TestCase):
         needle = 'needle'
         assert d == {'a': 3}
         assert n == 10
-        assert l == [1, 2]        
+        assert l == [1, 2]
         assert s == {1, 2}
         assert t == (1, 2)
         assert needle in "haystack"
@@ -35,5 +36,4 @@ class Test(TestCase):
         assert 1
         assert 1.0
         """,
-                    *[m.AssertTrivallyTrue]*8)
-
+                    *[m.AssertTrivallyTrue] * 8)


### PR DESCRIPTION
(authored by @clintonroy, patch submitted via LaunchPad)

Fixes lp:1405778.

I've come across numerous accidental uses of assert where the test
expression is a tuple of the actual test expression and the message,
which always succeeds as the bool of a non empty tuple is always true.

This patch catches the most obvious constants boolean expressions assed
along, certainly not all of them, but there shouldn't be any false
positives.