### PR TITLE
[#885140] Update del handling in if and while statements.

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -534,29 +534,12 @@ class Checker(object):
 
         def on_conditional_branch():
             """
-            Return `True` if node is part of a conditional branch.
+            Return `True` if node is part of a conditional body.
             """
             current = getattr(node, 'parent', None)
             while current:
-                if isinstance(current, ast.If):
+                if isinstance(current, (ast.If, ast.While, ast.IfExp)):
                     return True
-                current = getattr(current, 'parent', None)
-            return False
-
-        def is_part_of_while_conditional():
-            """
-            Return `True` if node is part of left or right side of a while
-            test.
-            """
-            current = getattr(node, 'parent', None)
-            while current:
-                if isinstance(current, ast.While):
-                    for descendant in ast.walk(current.test):
-                        if not isinstance(descendant, ast.Name):
-                            continue
-                        if not node.id == descendant.id:
-                            continue
-                        return True
                 current = getattr(current, 'parent', None)
             return False
 
@@ -567,9 +550,6 @@ class Checker(object):
         if on_conditional_branch():
             # We can not predict if this conditional branch is going to
             # be executed.
-            return
-
-        if is_part_of_while_conditional():
             return
 
         if isinstance(self.scope, FunctionScope) and name in self.scope.globals:

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -158,7 +158,7 @@ class Test(TestCase):
             foo = 'bar'
             while False:
                 del foo
-            print foo
+            assert(foo)
         ''')
 
     def test_delWhileTestUsage(self):

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -150,25 +150,26 @@ class Test(TestCase):
 
     def test_delWhile(self):
         """
-        Ignore bindings deletion if node is part of while test's left side.
+        Ignore bindings deletion if called inside the body of a while
+        statement.
+        """
+        self.flakes('''
+        def test():
+            foo = 'bar'
+            while False:
+                del foo
+            print foo
+        ''')
+
+    def test_delWhileTestUsage(self):
+        """
+        Ignore bindings deletion if called inside the body of a while
+        statement and name is used inside while's test part.
         """
         self.flakes('''
         def _worker():
             o = True
             while o is not True:
-                del o
-                o = False
-        ''')
-
-    def test_delWhileRightSide(self):
-        """
-        Ignore bindings deletion if node is part of while test's right side.
-        """
-        self.flakes('''
-        def _worker():
-            a = False
-            o = True
-            while a == o:
                 del o
                 o = False
         ''')


### PR DESCRIPTION
Problem
=======

"del" handling in conditional blocks is to optimistic and assumes that the branch will always be executed.

"del" handling does not take into consideration the fact that a variable is used as part of a while test.

Changes
=======

Update handleNodeDelete to not remove the variable from the scope when del call is on a conditional branch or when is part of while's test scope.

I tried to keep the tests simple. In case there are any problems I will update the test suite and update the code.

I wrote testes based on examples from https://bugs.launchpad.net/pyflakes/+bug/885140 and this code from Twisted https://github.com/twisted/twisted/blob/trunk/twisted/python/threadpool.py#L190


Tests
====

```$ python setup.py test -q``` all tests passed.

I also run tox, but I only have python 2.7 and 3.4 installed.

I have tested the new code on Twisted trunk and on my private project it looks good.
No false positives....but since the code was already clean I am not sure if this change introduces any false negatives.

Please take a look and let me know what needs to be changes.

Thanks!