### PR TITLE
[#1332451] Add an error for return outside of function.

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -693,6 +693,10 @@ class Checker(object):
             raise RuntimeError("Got impossible expression context: %r" % (node.ctx,))
 
     def RETURN(self, node):
+        if isinstance(self.scope, ClassScope):
+            self.report(messages.ReturnOutsideFunction, node)
+            return
+
         if (
             node.value and
             hasattr(self.scope, 'returnValue') and

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -133,3 +133,10 @@ class ReturnWithArgsInsideGenerator(Message):
     Indicates a return statement with arguments inside a generator.
     """
     message = '\'return\' with argument inside generator'
+
+
+class ReturnOutsideFunction(Message):
+    """
+    Indicates a return statement outside of a function/method.
+    """
+    message = '\'return\' outside function'

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -340,6 +340,15 @@ class Test(TestCase):
             pass
         ''', m.RedefinedWhileUnused)
 
+    def test_classWithReturn(self):
+        """
+        If a return is used inside a class, a warning is emitted.
+        """
+        self.flakes('''
+        class Foo(object):
+            return
+        ''', m.ReturnOutsideFunction)
+
     @skip("todo: Too hard to make this warn but other cases stay silent")
     def test_doubleAssignment(self):
         """


### PR DESCRIPTION
Problem
======
See: https://bugs.launchpad.net/pyflakes/+bug/1332451

The code on master was already ignoring this error and no longer crashing.

Changes
=======

Create a dedicated errror but not sure if this is needed as it is already raised by python as a syntax error.


Check that changes make sense of just close this pull request and the Launchpad ticket.

Thanks!
