### PR TITLE
Properly support list comprehensions in Python 3

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -672,7 +672,7 @@ class Checker(object):
         EQ = NOTEQ = LT = LTE = GT = GTE = IS = ISNOT = IN = NOTIN = ignore
 
     # additional node types
-    LISTCOMP = COMPREHENSION = KEYWORD = handleChildren
+    COMPREHENSION = KEYWORD = handleChildren
 
     def GLOBAL(self, node):
         """
@@ -687,6 +687,8 @@ class Checker(object):
         self.pushScope(GeneratorScope)
         self.handleChildren(node)
         self.popScope()
+
+    LISTCOMP = handleChildren if PY2 else GENERATOREXP
 
     DICTCOMP = SETCOMP = GENERATOREXP
 

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -473,6 +473,8 @@ class Test(TestCase):
         self.flakes('import fu; [fu for _ in range(1)]')
         self.flakes('import fu; [1 for _ in range(1) if fu]')
 
+    @skipIf(version_info >= (3,),
+            'in Python 3 list comprehensions execute in a separate scope')
     def test_redefinedByListComp(self):
         self.flakes('import fu; [1 for fu in range(1)]',
                     m.RedefinedInListComp)

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -21,6 +21,8 @@ class Test(TestCase):
         f()
         ''', m.UndefinedLocal, m.UnusedVariable)
 
+    @skipIf(version_info >= (3,),
+            'in Python 3 list comprehensions execute in a separate scope')
     def test_redefinedInListComp(self):
         """
         Test that shadowing a variable in a list comprehension raises
@@ -220,6 +222,8 @@ class Test(TestCase):
             [a for a in '12']
         ''')
 
+    @skipIf(version_info >= (3,),
+            'in Python 3 list comprehensions execute in a separate scope')
     def test_redefinedElseInListComp(self):
         """
         Test that shadowing a variable in a list comprehension in

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -13,6 +13,15 @@ class Test(TestCase):
     def test_definedInListComp(self):
         self.flakes('[a for a in range(10) if a]')
 
+    @skipIf(version_info < (3,),
+            'in Python 2 list comprehensions execute in the same scope')
+    def test_undefinedInListComp(self):
+        self.flakes('''
+        [a for a in range(10)]
+        a
+        ''',
+                    m.UndefinedName)
+
     def test_functionsNeedGlobalScope(self):
         self.flakes('''
         class a:


### PR DESCRIPTION
I've modified the code to match the new behavior in Python 3.

https://docs.python.org/3/reference/expressions.html#displays-for-lists-sets-and-dictionaries

> Note that the comprehension is executed in a separate scope, so names assigned to in the target list don’t “leak” into the enclosing scope.