### PR TITLE
Add 'sudo: false' to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
 matrix:
   allow_failures:
     - python: pypy
+sudo: false


### PR DESCRIPTION
This allows Travis to use the Docker container infrastructure, which should
make builds start up faster. See
http://docs.travis-ci.com/user/workers/container-based-infrastructure/