### PR TITLE
Different exit codes for different cases

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -172,4 +172,10 @@ def main(prog=None):
         warnings = checkRecursive(args, reporter)
     else:
         warnings = check(sys.stdin.read(), '<stdin>', reporter)
-    raise SystemExit(warnings > 0)
+    if reporter.errors:
+        code = 2
+    elif reporter.warnings:
+        code = 1
+    else:
+        code = 0
+    sys.exit(code)

--- a/pyflakes/reporter.py
+++ b/pyflakes/reporter.py
@@ -22,6 +22,8 @@ class Reporter(object):
             written to.  The stream's C{write} method must accept unicode.
             C{sys.stderr} is a good value.
         """
+        self.warnings = []
+        self.errors = []
         self._stdout = warningStream
         self._stderr = errorStream
 
@@ -35,6 +37,7 @@ class Reporter(object):
         @ptype msg: C{unicode}
         """
         self._stderr.write("%s: %s\n" % (filename, msg))
+        self.errors.append(filename)
 
     def syntaxError(self, filename, msg, lineno, offset, text):
         """
@@ -63,6 +66,7 @@ class Reporter(object):
         if offset is not None:
             self._stderr.write(re.sub(r'\S', ' ', line[:offset]) +
                                "^\n")
+        self.errors.append(filename)
 
     def flake(self, message):
         """
@@ -72,7 +76,7 @@ class Reporter(object):
         """
         self._stdout.write(str(message))
         self._stdout.write('\n')
-
+        self.warnings.append(message)
 
 def _makeDefaultReporter():
     """

--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -593,7 +593,7 @@ class IntegrationTests(TestCase):
         """
         d = self.runPyflakes([self.tempfilepath])
         error_msg = '%s: No such file or directory\n' % (self.tempfilepath,)
-        self.assertEqual(d, ('', error_msg, 1))
+        self.assertEqual(d, ('', error_msg, 2))
 
     def test_readFromStdin(self):
         """


### PR DESCRIPTION
To be able to run pyflakes as a script in a build pipeline for python code, it needs to differentiate between warnings and errors. Build pipelines should fail when there is a syntax error, but they can continue if there are only warnings from pyflakes.

Exit with code:
0 - No warnings or errors
1 - Only warnings
2 - Errors

Now one can do:
```bash
$ pyflakes module/
$ if [[ $? -eq 2 ]] 
...
```
but allow the code to pass if there are no errors, only warnings.