### PR TITLE
Don't mark shadowing variable as 'used'.

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -96,10 +96,11 @@ class Binding(object):
                 line number that this binding was last used
     """
 
-    def __init__(self, name, source):
+    def __init__(self, name, source, isglobal=False):
         self.name = name
         self.source = source
         self.used = False
+        self.isglobal = isglobal
 
     def __str__(self):
         return self.name
@@ -526,7 +527,7 @@ class Checker(object):
             binding = ExportBinding(name, node.parent, self.scope)
         else:
             binding = Assignment(name, node)
-        if name in self.scope:
+        if name in self.scope and self.scope[name].isglobal:
             binding.used = self.scope[name].used
         self.addBinding(node, binding)
 
@@ -687,7 +688,7 @@ class Checker(object):
 
             # One 'global' statement can bind multiple (comma-delimited) names.
             for node_name in node.names:
-                node_value = Assignment(node_name, node)
+                node_value = Assignment(node_name, node, isglobal=True)
 
                 # Remove UndefinedName messages already reported for this name.
                 self.messages = [

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -96,11 +96,10 @@ class Binding(object):
                 line number that this binding was last used
     """
 
-    def __init__(self, name, source, isglobal=False):
+    def __init__(self, name, source):
         self.name = name
         self.source = source
         self.used = False
-        self.isglobal = isglobal
 
     def __str__(self):
         return self.name
@@ -527,7 +526,8 @@ class Checker(object):
             binding = ExportBinding(name, node.parent, self.scope)
         else:
             binding = Assignment(name, node)
-        if name in self.scope and self.scope[name].isglobal:
+        if name in self.scope:
+            # then assume the rebound name is used as a global or within a loop
             binding.used = self.scope[name].used
         self.addBinding(node, binding)
 
@@ -688,7 +688,7 @@ class Checker(object):
 
             # One 'global' statement can bind multiple (comma-delimited) names.
             for node_name in node.names:
-                node_value = Assignment(node_name, node, isglobal=True)
+                node_value = Assignment(node_name, node)
 
                 # Remove UndefinedName messages already reported for this name.
                 self.messages = [

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -523,6 +523,17 @@ class TestUnusedAssignment(TestCase):
                 return
         ''', m.UnusedVariable)
 
+    def test_unusedReassignedVariable(self):
+        """
+        Shadowing a used variable can still raise an UnusedVariable warning.
+        """
+        self.flakes('''
+        def a():
+            b = 1
+            b.foo()
+            b = 2
+        ''', m.UnusedVariable)
+
     def test_assignToGlobal(self):
         """
         Assigning to a global and then not using that global is perfectly
@@ -604,7 +615,7 @@ class TestUnusedAssignment(TestCase):
                 if i > 2:
                     return x
                 x = i * 2
-        ''')
+        ''', m.UnusedVariable)
 
     def test_tupleUnpacking(self):
         """

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -523,6 +523,7 @@ class TestUnusedAssignment(TestCase):
                 return
         ''', m.UnusedVariable)
 
+    @skip("todo: Difficult because it does't apply in the context of a loop")
     def test_unusedReassignedVariable(self):
         """
         Shadowing a used variable can still raise an UnusedVariable warning.
@@ -627,7 +628,7 @@ class TestUnusedAssignment(TestCase):
                 if i > 2:
                     return x
                 x = i * 2
-        ''', m.UnusedVariable)
+        ''')
 
     def test_tupleUnpacking(self):
         """

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -534,6 +534,18 @@ class TestUnusedAssignment(TestCase):
             b = 2
         ''', m.UnusedVariable)
 
+    def test_variableUsedInLoop(self):
+        """
+        Shadowing a used variable cannot raise an UnusedVariable warning in the
+        context of a loop.
+        """
+        self.flakes('''
+        def a():
+            b = True
+            while b:
+                b = False
+        ''')
+
     def test_assignToGlobal(self):
         """
         Assigning to a global and then not using that global is perfectly

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -193,7 +193,7 @@ class Test(TestCase):
             while o is not True:
                 del o
                 o = False
-        ''')
+        ''', m.UnusedVariable)
 
     def test_delWhileNested(self):
         """
@@ -209,7 +209,7 @@ class Test(TestCase):
                     with context():
                         del o
                 o = False
-        ''')
+        ''', m.UnusedVariable)
 
     def test_globalFromNestedScope(self):
         """Global names are available from nested scopes."""
@@ -315,6 +315,7 @@ class Test(TestCase):
                 d += 4
                 e[any] = 5
             ''',
+            m.UnusedVariable,   # a
             m.UndefinedName,    # b
             m.UndefinedName,    # c
             m.UndefinedName, m.UnusedVariable,  # d

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -193,7 +193,7 @@ class Test(TestCase):
             while o is not True:
                 del o
                 o = False
-        ''', m.UnusedVariable)
+        ''')
 
     def test_delWhileNested(self):
         """
@@ -209,7 +209,7 @@ class Test(TestCase):
                     with context():
                         del o
                 o = False
-        ''', m.UnusedVariable)
+        ''')
 
     def test_globalFromNestedScope(self):
         """Global names are available from nested scopes."""
@@ -315,7 +315,6 @@ class Test(TestCase):
                 d += 4
                 e[any] = 5
             ''',
-            m.UnusedVariable,   # a
             m.UndefinedName,    # b
             m.UndefinedName,    # c
             m.UndefinedName, m.UnusedVariable,  # d


### PR DESCRIPTION
Shadowing a used variable should still potentially raise an
UnusedVariable warning. Alter tests' expected results to agree with
this premise.