### PR TITLE
Don't report UnusedImport when binding global name

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -448,6 +448,10 @@ class Checker(object):
             elif isinstance(existing, Importation) and value.redefines(existing):
                 existing.redefined.append(node)
 
+        if value.name in self.scope:
+            # then assume the rebound name is used as a global or within a loop
+            value.used = self.scope[value.name].used
+
         self.scope[value.name] = value
 
     def getNodeHandler(self, node_class):
@@ -526,9 +530,6 @@ class Checker(object):
             binding = ExportBinding(name, node.parent, self.scope)
         else:
             binding = Assignment(name, node)
-        if name in self.scope:
-            # then assume the rebound name is used as a global or within a loop
-            binding.used = self.scope[name].used
         self.addBinding(node, binding)
 
     def handleNodeDelete(self, node):

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -525,6 +525,16 @@ class Test(TestCase):
             def g(): foo.is_used()
         ''')
 
+    def test_assignedToGlobal(self):
+        """
+        Binding an import to a declared global should not cause it to be
+        reported as unused.
+        """
+        self.flakes('''
+            def f(): global foo; import foo
+            def g(): foo.is_used()
+        ''')
+
     @skipIf(version_info >= (3,), 'deprecated syntax')
     def test_usedInBackquote(self):
         self.flakes('import fu; `fu`')


### PR DESCRIPTION
When an import binds to a name declared global by the "global"
statment, don't report it as unused.