### PR TITLE
Use latest pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - nightly
   - pypy
 install:
-  - pip install flake8==2.1.0 pep8==1.5.6
+  - pip install flake8==2.1.0 git+https://github.com/PyCQA/pep8
   - python setup.py install
   - pip list
   - flake8 --version


### PR DESCRIPTION
The one on PyPI does not support Python 3.5. The fix was made a month ago, but has not been released yet.

https://github.com/PyCQA/pep8/pull/420