### PR TITLE
Avoid running flake8 under nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ install:
   - pip install flake8==2.1.0 pep8==1.5.6
   - python setup.py install
   - pip list
-  - flake8 --version
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then flake8 --version; fi
 script:
   - python setup.py test -q
-  - flake8 pyflakes setup.py
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then flake8 pyflakes setup.py; fi
 matrix:
   allow_failures:
     - python: pypy


### PR DESCRIPTION
PyPI's pep8 is not compatible with Python 3.5 yet.