### PR TITLE
Support Python 3.5 async/await statements for Pyflakes

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -649,8 +649,9 @@ class Checker(object):
         pass
 
     # "stmt" type nodes
-    DELETE = PRINT = FOR = WHILE = IF = WITH = WITHITEM = RAISE = \
-        TRYFINALLY = ASSERT = EXEC = EXPR = ASSIGN = handleChildren
+    DELETE = PRINT = FOR = ASYNCFOR = WHILE = IF = WITH = WITHITEM = \
+        ASYNCWITH = ASYNCWITHITEM = RAISE = TRYFINALLY = ASSERT = EXEC = \
+        EXPR = ASSIGN = handleChildren
 
     CONTINUE = BREAK = PASS = ignore
 
@@ -752,7 +753,7 @@ class Checker(object):
         self.scope.isGenerator = True
         self.handleNode(node.value, node)
 
-    YIELDFROM = YIELD
+    AWAIT = YIELDFROM = YIELD
 
     def FUNCTIONDEF(self, node):
         for deco in node.decorator_list:
@@ -761,6 +762,8 @@ class Checker(object):
         self.addBinding(node, FunctionDefinition(node.name, node))
         if self.withDoctest:
             self.deferFunction(lambda: self.handleDoctests(node))
+
+    ASYNCFUNCTIONDEF = FUNCTIONDEF
 
     def LAMBDA(self, node):
         args = []

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -988,3 +988,55 @@ class TestUnusedAssignment(TestCase):
     def test_returnOnly(self):
         """Do not crash on lone "return"."""
         self.flakes('return 2')
+
+
+class TestAsyncStatements(TestCase):
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_asyncDef(self):
+        self.flakes('''
+        async def bar():
+            return 42
+        ''')
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_asyncDefAwait(self):
+        self.flakes('''
+        async def read_data(db):
+            await db.fetch('SELECT ...')
+        ''')
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_asyncDefUndefined(self):
+        self.flakes('''
+        async def bar():
+            return foo()
+        ''', m.UndefinedName)
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_asyncFor(self):
+        self.flakes('''
+        async def read_data(db):
+            output = []
+            async for row in db.cursor():
+                output.append(row)
+            return output
+        ''')
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_asyncWith(self):
+        self.flakes('''
+        async def commit(session, data):
+            async with session.transaction():
+                await session.update(data)
+        ''')
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_asyncWithItem(self):
+        self.flakes('''
+        async def commit(session, data):
+            async with session.transaction() as trans:
+                await trans.begin()
+                ...
+                await trans.end()
+        ''')


### PR DESCRIPTION
This PR add support of statements from [PEP 492](https://www.python.org/dev/peps/pep-0492/) to Pyflakes.

----

To test:

* Install Python 3.5.0rc2 as `pyenv install 3.5.0rc2`
* Set 3.5.0rc2 as default Python for the pyflakes as `pyenv local 3.5.0rc`
* Install tox, `pip install tox` and run tests as `tox -e py35`
* Check that everything works properly

----

I did not enabled `py35` in tox envlist as I think it's a little bit pre-mature.