### PR TITLE
PEP 498 f-strings support

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -675,7 +675,7 @@ class Checker(object):
         EQ = NOTEQ = LT = LTE = GT = GTE = IS = ISNOT = IN = NOTIN = ignore
 
     # additional node types
-    COMPREHENSION = KEYWORD = handleChildren
+    COMPREHENSION = KEYWORD = FORMATTEDVALUE = handleChildren
 
     def GLOBAL(self, node):
         """

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -989,6 +989,14 @@ class TestUnusedAssignment(TestCase):
         """Do not crash on lone "return"."""
         self.flakes('return 2')
 
+    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    def test_f_string(self):
+        """Test PEP 498 f-strings are treated as a usage."""
+        self.flakes('''
+        baz = 0
+        print(f'\x7b4*baz\N{RIGHT CURLY BRACKET}')
+        ''')
+
 
 class TestAsyncStatements(TestCase):
 


### PR DESCRIPTION
PEP 498 f-strings cause pyflakes to crash with
AttributeError: 'Checker' object has no attribute 'FORMATTEDVALUE'