### PR TITLE
Fix global removing all UndefinedName

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -693,10 +693,12 @@ class Checker(object):
                 node_value = Assignment(node_name, node)
 
                 # Remove UndefinedName messages already reported for this name.
+                # TODO: if the global is not used in this scope, it does not
+                # become a globally defined name.  See test_unused_global.
                 self.messages = [
                     m for m in self.messages if not
-                    isinstance(m, messages.UndefinedName) and not
-                    m.message_args[0] == node_name]
+                    isinstance(m, messages.UndefinedName) or
+                    m.message_args[0] != node_name]
 
                 # Bind name to global scope if it doesn't exist already.
                 global_scope.setdefault(node_name, node_value)

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -3,7 +3,7 @@ from _ast import PyCF_ONLY_AST
 from sys import version_info
 
 from pyflakes import messages as m, checker
-from pyflakes.test.harness import TestCase, skipIf
+from pyflakes.test.harness import TestCase, skipIf, skip
 
 
 class Test(TestCase):
@@ -123,6 +123,29 @@ class Test(TestCase):
         global x
         def foo():
             print(x)
+        ''', m.UndefinedName)
+
+    def test_global_reset_name_only(self):
+        """A global statement does not prevent other names being undefined."""
+        # Only different undefined names are reported.
+        # See following test that fails where the same name is used.
+        self.flakes('''
+        def f1():
+            s
+
+        def f2():
+            global m
+        ''', m.UndefinedName)
+
+    @skip("todo")
+    def test_unused_global(self):
+        """An unused global statement does not define the name."""
+        self.flakes('''
+        def f1():
+            m
+
+        def f2():
+            global m
         ''', m.UndefinedName)
 
     def test_del(self):


### PR DESCRIPTION
03ffc763 introduced better global support,
however a logic error caused it to remove any
previously detected UndefinedName whenever
a global was encountered.