### PR TITLE
Merge test_doubleNestingReportsClosestName

### DIFF
--- a/pyflakes/test/test_doctests.py
+++ b/pyflakes/test/test_doctests.py
@@ -376,22 +376,5 @@ class TestImports(_DoctestMixin, TestImports):
 
 
 class TestUndefinedNames(_DoctestMixin, TestUndefinedNames):
-
-    def test_doubleNestingReportsClosestName(self):
-        """
-        Lines in doctest are a bit different so we can't use the test
-        from TestUndefinedNames
-        """
-        exc = self.flakes('''
-        def a():
-            x = 1
-            def b():
-                x = 2 # line 7 in the file
-                def c():
-                    x
-                    x = 3
-                    return x
-                return x
-            return x
-        ''', m.UndefinedLocal).messages[0]
-        self.assertEqual(exc.message_args, ('x', 7))
+    """Run TestUndefinedNames with each test wrapped in a doctest."""
+    pass

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -309,7 +309,11 @@ class Test(TestCase):
                     return x
                 return x
         ''', m.UndefinedLocal).messages[0]
-        self.assertEqual(exc.message_args, ('x', 5))
+
+        # _DoctestMixin.flakes adds two lines preceding the code above.
+        expected_line_num = 7 if self.withDoctest else 5
+
+        self.assertEqual(exc.message_args, ('x', expected_line_num))
 
     def test_laterRedefinedGlobalFromNestedScope3(self):
         """


### PR DESCRIPTION
The test_doubleNestingReportsClosestName in test_doctest only
differs by the expected line number of the error, which can
be dynamically determined using TestCase.withDoctest.