### PR TITLE
Allow __future__ in doctest

### DIFF
--- a/pyflakes/test/test_doctests.py
+++ b/pyflakes/test/test_doctests.py
@@ -431,18 +431,12 @@ class Test(TestCase):
 
 
 class TestOther(_DoctestMixin, TestOther):
-    pass
+    """Run TestOther with each test wrapped in a doctest."""
 
 
 class TestImports(_DoctestMixin, TestImports):
-
-    def test_futureImport(self):
-        """XXX This test can't work in a doctest"""
-
-    def test_futureImportUsed(self):
-        """XXX This test can't work in a doctest"""
+    """Run TestImports with each test wrapped in a doctest."""
 
 
 class TestUndefinedNames(_DoctestMixin, TestUndefinedNames):
     """Run TestUndefinedNames with each test wrapped in a doctest."""
-    pass


### PR DESCRIPTION
Deprecate Checker.futuresAllowed as it is now unused,
and is typically unnecessary.