### PR TITLE
Always report imports shadowed by another import

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -449,8 +449,14 @@ class Checker(object):
                     self.report(messages.RedefinedWhileUnused,
                                 node, value.name, existing.source)
 
-            elif isinstance(existing, Importation) and value.redefines(existing):
-                existing.redefined.append(node)
+            elif isinstance(existing, Importation):
+                if isinstance(node, (ast.Import, ast.ImportFrom)):
+                    if not isinstance(self.scope, DoctestScope):
+                        self.report(messages.ImportShadowedByImport,
+                                    node, value.name, existing.source)
+
+                elif value.redefines(existing):
+                    existing.redefined.append(node)
 
         if value.name in self.scope:
             # then assume the rebound name is used as a global or within a loop

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -41,6 +41,14 @@ class RedefinedInListComp(Message):
         self.message_args = (name, orig_loc.lineno)
 
 
+class ImportShadowedByImport(Message):
+    message = 'import %r from line %r shadowed by import'
+
+    def __init__(self, filename, loc, name, orig_loc):
+        Message.__init__(self, filename, loc)
+        self.message_args = (name, orig_loc.lineno)
+
+
 class ImportShadowedByLoopVar(Message):
     message = 'import %r from line %r shadowed by loop variable'
 

--- a/pyflakes/test/test_doctests.py
+++ b/pyflakes/test/test_doctests.py
@@ -9,7 +9,7 @@ from pyflakes.checker import (
 from pyflakes.test.test_other import Test as TestOther
 from pyflakes.test.test_imports import Test as TestImports
 from pyflakes.test.test_undefined_names import Test as TestUndefinedNames
-from pyflakes.test.harness import TestCase, skip
+from pyflakes.test.harness import TestCase
 
 
 class _DoctestMixin(object):
@@ -193,7 +193,6 @@ class Test(TestCase):
             '''
         """)
 
-    @skip("todo")
     def test_importBeforeAndInDoctest(self):
         self.flakes('''
         import foo
@@ -205,7 +204,7 @@ class Test(TestCase):
             """
 
         foo
-        ''', m.RedefinedWhileUnused)
+        ''')
 
     def test_importInDoctestAndAfter(self):
         self.flakes('''

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -184,9 +184,8 @@ class Test(TestCase):
             def baz():
                 def fu():
                     pass
-        ''',
-                    m.RedefinedWhileUnused, m.RedefinedWhileUnused,
-                    m.UnusedImport, m.UnusedImport)
+        ''', *(m.ImportShadowedByImport, m.RedefinedWhileUnused,
+               m.UnusedImport, m.UnusedImport))
 
     def test_redefinedButUsedLater(self):
         """
@@ -563,6 +562,15 @@ class Test(TestCase):
             import fu
         fu
         ''', m.UnusedImport, m.UndefinedName)
+
+    def test_shadowedInNestedScope(self):
+        self.flakes('''
+        import fu
+        def bar():
+            import fu
+            fu
+        fu
+        ''', m.ImportShadowedByImport)
 
     def test_methodsDontUseClassScope(self):
         self.flakes('''


### PR DESCRIPTION
Previously only unused imports redefined by another
imports were reported as RedefinedWhileUnused.

A new ImportShadowedByImport message now always
reports the re-import except when an import in the
doctest scope shadows an import in the module scope.