### PR TITLE
Handle matrix-multiplication operator ("@")

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -767,7 +767,8 @@ class Checker(object):
     # same for operators
     AND = OR = ADD = SUB = MULT = DIV = MOD = POW = LSHIFT = RSHIFT = \
         BITOR = BITXOR = BITAND = FLOORDIV = INVERT = NOT = UADD = USUB = \
-        EQ = NOTEQ = LT = LTE = GT = GTE = IS = ISNOT = IN = NOTIN = ignore
+        EQ = NOTEQ = LT = LTE = GT = GTE = IS = ISNOT = IN = NOTIN = \
+        MATMULT = ignore
 
     # additional node types
     COMPREHENSION = KEYWORD = FORMATTEDVALUE = handleChildren

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1736,3 +1736,10 @@ class TestAsyncStatements(TestCase):
                 ...
                 await trans.end()
         ''')
+
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
+    def test_matmul(self):
+        self.flakes('''
+        def foo(a, b):
+            return a @ b
+        ''')


### PR DESCRIPTION
https://docs.python.org/3.6/whatsnew/3.5.html#pep-465-a-dedicated-infix-operator-for-matrix-multiplication

This fixes https://bugs.launchpad.net/pyflakes/+bug/1523163.