### PR TITLE
RFC: checking call sites for invalid keyword parameters

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -726,7 +726,6 @@ class Checker(object):
     def handleCall(self, call):
         # checks only keywords for now.
         # TODO - check positional arguments as well
-        used_keywords = {k.arg for k in call.keywords}
         function_name = getNodeName(call.func)
         assert function_name is not None # 'attr' in call.func._fields ?
         try:
@@ -735,9 +734,22 @@ class Checker(object):
             self.report('{} not in scope {}, error'.format(function_name, self.scope))
             return
         fdef = func_binding.source
+        if isinstance(fdef, ast.FunctionDef):
+            self.validateCall(fdef, call)
+        elif isinstance(fdef, ast.Import):
+            self.validateImportCall(fdef, call)
+        else:
+            assert False, "unexpected call binding: not Import, not FunctionDef"
+
+    def validateImportCall(self, importdef, call):
+        print("TODO")
+
+    def validateCall(self, fdef, call):
         if fdef.args.kwarg is not None:
             # ignore calls to double star functions
             return
+        used_keywords = {k.arg for k in call.keywords}
+        function_name = getNodeName(call.func)
         valid_keywords = {arg.id for arg in fdef.args.args}
         for k in used_keywords - valid_keywords:
             self.report(messages.InvalidKeywordInCall, call, function_name=function_name,

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -742,7 +742,8 @@ class Checker(object):
             assert False, "unexpected call binding: not Import, not FunctionDef"
 
     def validateImportCall(self, importdef, call):
-        print("TODO")
+        #print("TODO")
+        pass
 
     def validateCall(self, fdef, call):
         if fdef.args.kwarg is not None:

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -215,3 +215,15 @@ class AssertTuple(Message):
     Assertion test is a tuple, which are always True.
     """
     message = 'assertion is always true, perhaps remove parentheses?'
+
+
+class InvalidKeywordInCall(Message):
+    """
+    Call uses a keyword that is not defined in the function definition.
+    """
+    message = 'call to %r got invalid keyword %r. valid keywords are %r'
+
+    def __init__(self, filename, loc, function_name, wrong_keyword, valid_keywords):
+        Message.__init__(self, filename, loc)
+        self.message_args = (function_name, wrong_keyword, list(valid_keywords))
+

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1749,4 +1749,4 @@ class TestAsyncStatements(TestCase):
         def foo(a):
             pass
         foo(b=1)
-        ''')
+        ''', m.InvalidKeywordInCall)

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1743,3 +1743,10 @@ class TestAsyncStatements(TestCase):
         def foo(a, b):
             return a @ b
         ''')
+
+    def test_callKeywords(self):
+        self.flakes('''
+        def foo(a):
+            pass
+        foo(b=1)
+        ''')


### PR DESCRIPTION
Hi,

 This patchset is RFC quality, I'm submitting it not for inclusion but for the discussion. What I want to support is checking of call sites between modules. The patch only does the check for the same module, i.e. the added test shows the usage:

```python
def f(x):
   pass

f(y=10) # will report a wrong call, y is invalid, only x is possible
```

But I really want to be able to support the same test with f defined in foo:

```python
# g.py
from foo import f
f(y=10) # report same error

# foo.py
def f(x)
  pass
```

To support that I'd have to break pyflakes one file at a time parsing. I can do it completely optionally, i.e. only when called on a group of files, so it would not break and won't add any runtime requirements on existing users.

Would that be something that anyone would be interested in?