### PR TITLE
Suppress RedefinedWhileUnused for submodule import

### DIFF
--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -767,6 +767,12 @@ class Test(TestCase):
         fu.x
         ''')
 
+        self.flakes('''
+        import fu.bar
+        import fu
+        fu.x
+        ''')
+
     def test_unused_package_with_submodule_import(self):
         """
         When a package and its submodule are imported, only report once.


### PR DESCRIPTION
Fixes lp:1578051

aec68a7 added module names to error messages, which included
a new class SubmoduleImportation to handle the special case
of submodule imports.  It correctly handled the case of
a submodule import occurring after the root module was imported,
but didnt handle the opposite case of the submodule import
occurring before the root module was imported.