### PR TITLE
Avoid traceback when exception is del-ed in except

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 *.pyc
 .tox
+/.cache/
 /dist/
 /build/
 docs/_build

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1212,4 +1212,10 @@ class Checker(object):
             # if the except: block is never entered. This will cause an
             # "undefined name" error raised if the checked code tries to
             # use the name afterwards.
-            del self.scope[node.name]
+            #
+            # Unless it's been removed already. Then do nothing.
+
+            try:
+                del self.scope[node.name]
+            except KeyError:
+                pass

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -97,6 +97,15 @@ class Test(TestCase):
         exc
         ''')
 
+    def test_delExceptionInExcept(self):
+        """The exception name can be deleted in the except: block."""
+        self.flakes('''
+        try:
+            pass
+        except Exception as exc:
+            del exc
+        ''')
+
     def test_undefinedExceptionNameObscuringLocalVariableFalsePositive2(self):
         """Exception names obscure locals, can't be used after. Unless.
 


### PR DESCRIPTION
Fixes a regression introduced by
2a698f87c02a43d4489e30481e9def14ed4b4431.

This would fail with a KeyError:

try:
    pass
except Exception as e:
    del e

Fixes lp:1578903